### PR TITLE
Update arvoreGeneologica.pl

### DIFF
--- a/arvoreGeneologica.pl
+++ b/arvoreGeneologica.pl
@@ -80,9 +80,15 @@ irmao(X,Y) :- sexo(X,masculino), progenitor(Z,Y), progenitor(Z,X) , X \== Y.
 
 irma(X,Y) :- sexo(X,feminino), progenitor(Z,Y),progenitor(Z,X), X \== Y.
 
-primo(X,Y) :- sexo(X,masculino), progenitor(Z,X), irmao(Z,P), progenitor(P,Y).
+primo(X,Y) :- sexo(X,masculino), progenitor(Z,X), progenitor(P,Y), irmao(Z,P); irma(Z,P), X \== Y.
 
-prima(X,Y) :- sexo(X, feminino), progenitor(Z,X), irmao(Z,P), progenitor(P,Y).
+
+irmao(X,Y) :- sexo(X,masculino), progenitor(Z,Y), progenitor(Z,X) , X \== Y.
+
+irma(X,Y) :- sexo(X,feminino), progenitor(Z,Y),progenitor(Z,X), X \== Y.
+
+primo(X,Y) :- sexo(X,masculino), progenito
+prima(X,Y) :- sexo(X, feminino), progenitor(Z,X), progenitor(P,Y), irmao(Z,P); irma(Z,P), X \== Y.
 
 tio(X,Y)   :- sexo(X,masculino) ,  progenitor(P,Y),  irmao(P,X). 
 


### PR DESCRIPTION
Alterei as regras primo e prima porque o X pode ser primo de Y apartir da relação que seus progenitores pai ou mãe podem ser irmão ou irmã dos progenitores de Y

**Ex**
Yuri -> Progenitor de -> Eufranio
Isaura -> Progenitora de -> Creuma

Yuri e Isaura são irmãos

então quando fizer a busca do pai de Eufranio que é yuri eu digo que yuri pode ser irmão ou irmã de progrenitor de Creuma que nesse caso é Isaura.
O inversos podes tentar.